### PR TITLE
fix: unzip all assets zis close

### DIFF
--- a/RNhotupdate/android/src/main/java/com/rnhotupdate/HotUpdateModule.java
+++ b/RNhotupdate/android/src/main/java/com/rnhotupdate/HotUpdateModule.java
@@ -81,8 +81,8 @@ public class HotUpdateModule extends ReactContextBaseJavaModule {
                 if (newFile.getAbsolutePath().contains(".bundle")) {
                     bundleFilePath = newFile.getAbsolutePath();
                 }
-                zis.closeEntry();
             }
+            zis.closeEntry();
         } catch (Exception e) {
             return null;
         }


### PR DESCRIPTION
This fix moves zis.close function out of the loop, so all assets will be unzipped