### PR TITLE
feat: add restartDelay option

### DIFF
--- a/DOC_OTA_GIT.md
+++ b/DOC_OTA_GIT.md
@@ -147,6 +147,7 @@ const onCheckGitVersion = () => {
 | Key                   | Required | Type       | Description                                                                                   |
 | --------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------- |
 | `restartAfterInstall` | No       | `boolean`  | Default is `false`. If `true`, the app will restart automatically after applying the changes. |
+| `restartDelay`        | No       | `number`   | Time in milliseconds to wait before restarting the app after an update. Defaults: `300ms`.   |
 | `branch`              | Yes      | `string`   | The Git branch to pull updates from (e.g., `iOS` or `android`).                               |
 | `bundlePath`          | Yes      | `string`   | The relative path to the bundle file within the repository.                                   |
 | `url`                 | Yes      | `string`   | The URL of the Git repository hosting the bundle files.                                       |

--- a/DOC_OTA_SERVER.md
+++ b/DOC_OTA_SERVER.md
@@ -123,6 +123,7 @@ Other CMS options include CraftCMS and PayloadCMS.
 | `updateSuccess`         | No       | `Callback` | Triggered when the update is installed successfully.                                             |
 | `updateFail`            | No       | `Callback` | Triggered when the update fails. Passes a `message` parameter.                                   |
 | `restartAfterInstall`   | No       | `boolean`  | Defaults to `false`. If `true`, restarts the app after a successful installation.                |
+| `restartDelay`          | No       | `number`   | Time in milliseconds to wait before restarting the app after an update. Defaults: `300ms`.      |
 | `progress`              | No       | `Callback` | Reports download progress.                                                                      |
 | `extensionBundle`       | No       | `string`   | Extension of the bundle file. Defaults: `.bundle` (Android), `.jsbundle` (iOS).                 |
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -154,7 +154,7 @@ async function downloadBundleUri(
     if (option?.restartAfterInstall) {
       setTimeout(() => {
         resetApp();
-      }, option?.restartDelay ?? 300);
+      }, option?.restartDelay || 300);
     }
   } catch (e) {
     installFail(option, e);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -154,7 +154,7 @@ async function downloadBundleUri(
     if (option?.restartAfterInstall) {
       setTimeout(() => {
         resetApp();
-      }, 300);
+      }, option?.restartDelay ?? 300);
     }
   } catch (e) {
     installFail(option, e);

--- a/src/type.ts
+++ b/src/type.ts
@@ -30,6 +30,12 @@ export interface UpdateOption {
   restartAfterInstall?: boolean;
 
   /**
+   * Delay in milliseconds before restarting the app after installing the update.
+   * Default: 300ms.
+   */
+  restartDelay?: number;
+
+  /**
    * Custom extension for the bundle file, if applicable.
    * For example: '.jsbundle'.
    */


### PR DESCRIPTION
## Why

The `restartAfterInstall` option in OTA updates had a hardcoded timeout of `300ms` before restarting the app.  
This made it feel like the app restarted too quickly, preventing a smooth transition.  

## How

To improve flexibility, `restartDelay` is set by the developer.

## Related Issue

- #67 

### [AS-IS]

```ts
setTimeout(() => {
  resetApp();
}, 300);
```

### [TO-BE]

```ts
setTimeout(() => {
  resetApp();
}, option?.restartDelay ?? 300);
```

<div>

<div align="center">
<img src="https://github.com/user-attachments/assets/a688555f-3f51-41bb-bcfb-3b74b7f7578b" width="180" alt="default" />
<img src="https://github.com/user-attachments/assets/75896f37-e6d7-4273-9c52-62d548f74aa3" width="180" alt="user-defined" />
</div>
<div align="center">
<p> left - default (300ms) / right - user-defined (3000ms)
</div>
</div>