### PR TITLE
[Process/Feature] Save previous version to correctly show the actual version when a bundle has been rolled back

### DIFF
--- a/android/src/main/java/com/otahotupdate/OtaHotUpdateModule.kt
+++ b/android/src/main/java/com/otahotupdate/OtaHotUpdateModule.kt
@@ -12,6 +12,7 @@ import com.rnhotupdate.Common.CURRENT_VERSION_NAME
 import com.rnhotupdate.Common.PATH
 import com.rnhotupdate.Common.PREVIOUS_PATH
 import com.rnhotupdate.Common.VERSION
+import com.rnhotupdate.Common.PREVIOUS_VERSION
 import com.rnhotupdate.Common.METADATA
 import com.rnhotupdate.SharedPrefs
 import java.io.File
@@ -168,6 +169,12 @@ class OtaHotUpdateModule internal constructor(context: ReactApplicationContext) 
   @ReactMethod
   override fun setCurrentVersion(version: String?, promise: Promise) {
     val sharedPrefs = SharedPrefs(reactApplicationContext)
+
+    val currentVersion = sharedPrefs.getString(VERSION)
+    if (currentVersion != "") {
+        sharedPrefs.putString(PREVIOUS_VERSION, currentVersion)
+    }
+
     sharedPrefs.putString(VERSION, version)
     promise.resolve(true)
   }
@@ -203,11 +210,21 @@ class OtaHotUpdateModule internal constructor(context: ReactApplicationContext) 
   override fun rollbackToPreviousBundle(a: Double, promise: Promise) {
     val sharedPrefs = SharedPrefs(reactApplicationContext)
     val oldPath = sharedPrefs.getString(PREVIOUS_PATH)
+    val previousVersion = sharedPrefs.getString(PREVIOUS_VERSION)
+
     if (oldPath != "") {
       val isDeleted = deleteOldBundleIfneeded(PATH)
       if (isDeleted) {
         sharedPrefs.putString(PATH, oldPath)
         sharedPrefs.putString(PREVIOUS_PATH, "")
+
+        if (previousVersion != "") {
+            sharedPrefs.putString(VERSION, previousVersion)
+            sharedPrefs.putString(PREVIOUS_VERSION, "")
+        } else {
+            sharedPrefs.putString(VERSION, "")
+        }
+
         promise.resolve(true)
       } else {
         promise.resolve(false)

--- a/android/src/main/java/com/otahotupdate/OtaHotUpdateModule.kt
+++ b/android/src/main/java/com/otahotupdate/OtaHotUpdateModule.kt
@@ -171,7 +171,7 @@ class OtaHotUpdateModule internal constructor(context: ReactApplicationContext) 
     val sharedPrefs = SharedPrefs(reactApplicationContext)
 
     val currentVersion = sharedPrefs.getString(VERSION)
-    if (currentVersion != "") {
+    if (currentVersion != "" && currentVersion != version) {
         sharedPrefs.putString(PREVIOUS_VERSION, currentVersion)
     }
 

--- a/android/src/main/java/com/otahotupdate/SharedPrefs.kt
+++ b/android/src/main/java/com/otahotupdate/SharedPrefs.kt
@@ -27,6 +27,7 @@ object Common {
     val PATH = "PATH"
     val PREVIOUS_PATH = "PREVIOUS_PATH"
     val VERSION = "VERSION"
+    val PREVIOUS_VERSION = "PREVIOUS_VERSION"
     val CURRENT_VERSION_NAME = "CURRENT_VERSION_NAME"
     val SHARED_PREFERENCE_NAME = "HOT-UPDATE-REACT_NATIVE"
     val DEFAULT_BUNDLE = "assets://index.android.bundle"

--- a/ios/OtaHotUpdate.mm
+++ b/ios/OtaHotUpdate.mm
@@ -244,6 +244,14 @@ RCT_EXPORT_METHOD(rollbackToPreviousBundle:(double)i
     if (oldPath && [self isFilePathValid:oldPath]) {
       BOOL isDeleted = [self removeBundleIfNeeded:@"PATH"];
       if (isDeleted) {
+        NSString *previousVersion = [defaults stringForKey:@"PREVIOUS_VERSION"];
+        if (previousVersion) {
+          [defaults setObject:currentVersion forKey:@"VERSION"];
+          [defaults removeObjectForKey:@"PREVIOUS_VERSION"];
+        } else {
+          [defaults removeObjectForKey:@"VERSION"];
+        }
+
         [defaults setObject:oldPath forKey:@"PATH"];
         [defaults removeObjectForKey:@"OLD_PATH"];
         [defaults synchronize];
@@ -272,8 +280,14 @@ RCT_EXPORT_METHOD(getCurrentVersion:(double)a
 RCT_EXPORT_METHOD(setCurrentVersion:(NSString *)version
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *currentVersion = [defaults stringForKey:@"VERSION"];
+    if (currentVersion) {
+        [defaults setObject:currentVersion forKey:@"PREVIOUS_VERSION"];
+        [defaults synchronize];
+    }
+
     if (version) {
-        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
         [defaults setObject:version forKey:@"VERSION"];
         [defaults synchronize];
         resolve(@(YES));

--- a/ios/OtaHotUpdate.mm
+++ b/ios/OtaHotUpdate.mm
@@ -282,11 +282,12 @@ RCT_EXPORT_METHOD(setCurrentVersion:(NSString *)version
                   reject:(RCTPromiseRejectBlock)reject) {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSString *currentVersion = [defaults stringForKey:@"VERSION"];
-    if (currentVersion && currentVersion != version) {
-        [defaults setObject:currentVersion forKey:@"PREVIOUS_VERSION"];
-    }
 
     if (version) {
+        if (currentVersion && currentVersion != version) {
+            [defaults setObject:currentVersion forKey:@"PREVIOUS_VERSION"];
+        }
+
         [defaults setObject:version forKey:@"VERSION"];
         [defaults synchronize];
         resolve(@(YES));

--- a/ios/OtaHotUpdate.mm
+++ b/ios/OtaHotUpdate.mm
@@ -284,7 +284,6 @@ RCT_EXPORT_METHOD(setCurrentVersion:(NSString *)version
     NSString *currentVersion = [defaults stringForKey:@"VERSION"];
     if (currentVersion && currentVersion != version) {
         [defaults setObject:currentVersion forKey:@"PREVIOUS_VERSION"];
-        [defaults synchronize];
     }
 
     if (version) {

--- a/ios/OtaHotUpdate.mm
+++ b/ios/OtaHotUpdate.mm
@@ -282,7 +282,7 @@ RCT_EXPORT_METHOD(setCurrentVersion:(NSString *)version
                   reject:(RCTPromiseRejectBlock)reject) {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSString *currentVersion = [defaults stringForKey:@"VERSION"];
-    if (currentVersion) {
+    if (currentVersion && currentVersion != version) {
         [defaults setObject:currentVersion forKey:@"PREVIOUS_VERSION"];
         [defaults synchronize];
     }


### PR DESCRIPTION
## Why
I was adding react-native-ota-update to a project, when I found out the version is not set back in any way when a bundle is rolled back. I found it strange, since the bundle itsself does reset. This might end up being a hazard when a user is reporting bugs from an OTA version, he doesn't even have.

## How
Every time the version is set, I check if another version was already saved at that point. If it was, I was save that version as the previous version.

## Related Issue
I did not create an issue for this;