### PR TITLE
[Bug] Fix breaking undefined variable "currentVersion" in AppDelegate.mm

### DIFF
--- a/ios/OtaHotUpdate.mm
+++ b/ios/OtaHotUpdate.mm
@@ -284,7 +284,7 @@ RCT_EXPORT_METHOD(rollbackToPreviousBundle:(double)i
       if (isDeleted) {
         NSString *previousVersion = [defaults stringForKey:@"PREVIOUS_VERSION"];
         if (previousVersion) {
-          [defaults setObject:currentVersion forKey:@"VERSION"];
+          [defaults setObject:previousVersion forKey:@"VERSION"];
           [defaults removeObjectForKey:@"PREVIOUS_VERSION"];
         } else {
           [defaults removeObjectForKey:@"VERSION"];


### PR DESCRIPTION
## Why
Currently it breaks because currentVersion does not exist.
## How
It breaks when running the app in expo
## Actual error
>  285 |         NSString *previousVersion = [defaults stringForKey:@"PREVIOUS_VERSION"];
    286 |         if (previousVersion) {
    287 |           [defaults setObject:currentVersion forKey:@"VERSION"];
      |                               ^ use of undeclared identifier 'currentVersion'
    288 |           [defaults removeObjectForKey:@"PREVIOUS_VERSION"];
    289 |         } else {
    290 |           [defaults removeObjectForKey:@"VERSION"];

## Related Issue