### PR TITLE
[Expo Plugin] Check if statement already exists before replacing it

### DIFF
--- a/plugin/build/index.js
+++ b/plugin/build/index.js
@@ -3,20 +3,26 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const withAndroidAction = (config) => {
     return (0, config_plugins_1.withMainApplication)(config, (config) => {
-        config.modResults.contents = config.modResults.contents.replace(/override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED/g, `
+        if (!config.modResults.contents.includes('override fun getJSBundleFile(): String = OtaHotUpdate.bundleJS(this@MainApplication)')) {
+            config.modResults.contents = config.modResults.contents.replace(/override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED/g, `
           override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
           override fun getJSBundleFile(): String = OtaHotUpdate.bundleJS(this@MainApplication)`);
-        config.modResults.contents = config.modResults.contents.replace(/import expo.modules.ReactNativeHostWrapper/g, `
+        }
+        if (!config.modResults.contents.includes('import com.otahotupdate.OtaHotUpdate')) {
+            config.modResults.contents = config.modResults.contents.replace(/import expo.modules.ReactNativeHostWrapper/g, `
 import expo.modules.ReactNativeHostWrapper
 import com.otahotupdate.OtaHotUpdate`);
+        }
         return config;
     });
 };
 const withIosAction = (config) => {
     return (0, config_plugins_1.withAppDelegate)(config, (config) => {
-        config.modResults.contents = config.modResults.contents.replace(/#import "AppDelegate.h"/g, `#import "AppDelegate.h"
+        if (!config.modResults.contents.includes('#import "OtaHotUpdate.h')) {
+            config.modResults.contents = config.modResults.contents.replace(/#import "AppDelegate.h"/g, `#import "AppDelegate.h"
 #import "OtaHotUpdate.h"`);
+        }
         config.modResults.contents = config.modResults.contents.replace(/\[\[NSBundle mainBundle\] URLForResource:@\"main\" withExtension:@\"jsbundle\"\]/, `[OtaHotUpdate getBundle]`);
         return config;
     });

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,30 +1,38 @@
 import { withMainApplication, withAppDelegate } from '@expo/config-plugins';
 const withAndroidAction: any = (config: any) => {
   return withMainApplication(config, (config) => {
-    config.modResults.contents = config.modResults.contents.replace(
-      /override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED/g,
-      `
+    if (!config.modResults.contents.includes('override fun getJSBundleFile(): String = OtaHotUpdate.bundleJS(this@MainApplication)')) {
+      config.modResults.contents = config.modResults.contents.replace(
+        /override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED/g,
+        `
           override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
 
           override fun getJSBundleFile(): String = OtaHotUpdate.bundleJS(this@MainApplication)`
-    );
-    config.modResults.contents = config.modResults.contents.replace(
-      /import expo.modules.ReactNativeHostWrapper/g,
-      `
+      );
+    }
+
+    if (!config.modResults.contents.includes('import com.otahotupdate.OtaHotUpdate')) {
+      config.modResults.contents = config.modResults.contents.replace(
+        /import expo.modules.ReactNativeHostWrapper/g,
+        `
 import expo.modules.ReactNativeHostWrapper
 import com.otahotupdate.OtaHotUpdate`
-    );
+      );
+    }
     return config;
   });
 };
 
 const withIosAction: any = (config: any) => {
   return withAppDelegate(config, (config) => {
-    config.modResults.contents = config.modResults.contents.replace(
-      /#import "AppDelegate.h"/g,
-      `#import "AppDelegate.h"
+    if (!config.modResults.contents.includes('#import "OtaHotUpdate.h')) {
+      config.modResults.contents = config.modResults.contents.replace(
+        /#import "AppDelegate.h"/g,
+        `#import "AppDelegate.h"
 #import "OtaHotUpdate.h"`
-    );
+      );
+    }
+
     config.modResults.contents = config.modResults.contents.replace(
       /\[\[NSBundle mainBundle\] URLForResource:@\"main\" withExtension:@\"jsbundle\"\]/,
       `[OtaHotUpdate getBundle]`


### PR DESCRIPTION
## Why

I was building my app for iOS and android with Expo. I got the error that the statement was defined multiple times.

## How

Have an Expo project en run Expo prebuild twice (or more) with react-native-ota-update configured in your app.json and you'll be able to reproduce it. 

## What is the fix

There is a check if the contents include the statement already, if so, do not replace a thing. If the statement is not included, then the replace action can be triggered.