### PR TITLE
fix(android): fallback to default bundle when stored path is missing

### DIFF
--- a/android/src/main/java/com/otahotupdate/OtaHotUpdate.kt
+++ b/android/src/main/java/com/otahotupdate/OtaHotUpdate.kt
@@ -3,6 +3,7 @@ package com.otahotupdate
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import java.io.File
 import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
@@ -66,7 +67,11 @@ class OtaHotUpdate : BaseReactPackage() {
       val pathBundle = sharedPrefs.getString(PATH)
       val version = sharedPrefs.getString(VERSION)
       val currentVersionName = sharedPrefs.getString(CURRENT_VERSION_CODE)
-      if (pathBundle == "" || (currentVersionName != context.getVersionCode())) {
+      val hasBundlePath = !pathBundle.isNullOrBlank()
+      val isSameAppVersion = currentVersionName == context.getVersionCode()
+      val bundleFileExists = hasBundlePath && File(pathBundle!!).isFile
+
+      if (!hasBundlePath || !isSameAppVersion || !bundleFileExists) {
         if (pathBundle != "") {
           sharedPrefs.putString(PATH, "")
         }


### PR DESCRIPTION
On some devices (e.g. Samsung with backup/restore), SharedPreferences can be restored after reinstall while the extracted OTA bundle file is not, leaving a stale PATH that points to a non-existent file. React Native then crashes trying to load the bundle (JSBigFileString::fromPath - Could not open file).

This change hardens OtaHotUpdate.bundleJS() by:

- validating that the stored bundle path is non-empty and points to an existing file
- clearing PATH and VERSION when the path is invalid, the file is missing, or the native app version code changed
- falling back to the embedded bundle (assets://index.android.bundle) instead of crashing

## Why
Prevents startup crashes caused by stale/restored SharedPreferences pointing to a missing OTA bundle.

example error from logcat below:
`unknown:BridgelessReact: ReactHost{0}.handleHostException(message = "JSBigFileString::fromPath - Could not open file: /data/user/0/<package_name>/files/output_20251114_140825/index.android.bundle")`

## How
Add a check to confirm that the bundle indicated in PATH exists, before committing to launching the app. 

## Related Issue
N/A