### PR TITLE
fix: add requiresMainQueueSetup for RN warning

### DIFF
--- a/ios/OtaHotUpdate.mm
+++ b/ios/OtaHotUpdate.mm
@@ -14,6 +14,9 @@ static BOOL isBeginning = YES;
 @implementation OtaHotUpdate
 RCT_EXPORT_MODULE()
 
++ (BOOL)requiresMainQueueSetup {
+  return NO;
+}
 
 - (instancetype)init {
     self = [super init];


### PR DESCRIPTION
##  Problem

React Native is showing a warning for the `OtaHotUpdate` native module:
This warning appears because the native module overrides `init`, but does not explicitly declare whether it should be initialized on the main thread or background thread.
<img width="1399" height="39" alt="截圖 2026-04-13 下午2 12 56" src="https://github.com/user-attachments/assets/0444ddec-8b10-4b7c-9683-fe538f9abce1" />

##  Changes

- Add `requiresMainQueueSetup` implementation returning `NO` to `OtaHotUpdate` native module

##  Related Issue
N/A

##  Notes

This module does not use UIKit or any main-thread-only APIs during initialization, so it is safe to initialize on a background thread.
This value can be updated to `YES` in the future if main-thread-only dependencies are introduced.
